### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,4 +33,4 @@ jobs:
       env:
         PYPI_TOKEN: ${{ secrets.EBERRIGAN_PYPI_TOKEN }}
       run: |
-        twine upload -u __token__ -p "$EBERRIGAN_PYPI_TOKEN" dist/* --non-interactive --skip-existing --disable-progress-bar
+        twine upload -u __token__ -p "$PYPI_TOKEN" dist/* --non-interactive --skip-existing --disable-progress-bar


### PR DESCRIPTION
- `PYPI_TOKEN` is used to upload the package to PyPI.org upon release