### PR TITLE
Fix undefined variable 'base' in Tree class popup method

### DIFF
--- a/src/ariadne_roots/main.py
+++ b/src/ariadne_roots/main.py
@@ -435,7 +435,7 @@ class TracerUI(tk.Frame):
         self.tree.clear_tree()
 
         # Prompt for a new plant ID assignment and create a new tree
-        self.tree.popup()
+        self.tree.popup(self.base)
 
     def draw_edge(self, parent, child):
         """Draw an edge between 2 nodes, and add it to the tree."""
@@ -646,7 +646,7 @@ class TracerUI(tk.Frame):
     def make_file(self, event=None):
         """Output tree data to file."""
         if self.tree.plant is None:  # get plant ID when called for the first time
-            self.tree.popup()
+            self.tree.popup(self.base)
             if self.tree.plant is None:  # user didn't update ID (pressed cancel)
                 return
 
@@ -768,7 +768,7 @@ class Tree:
         self.num_LRs = 0
         self.root_choice = None
 
-    def popup(self):
+    def popup(self, base):
         """Popup menu for plant ID assignment."""
         top = tk.Toplevel(base)
         top.geometry("350x500")


### PR DESCRIPTION
## Problem:
- The Tree class had a popup method that referenced an undefined variable `base`. 
- This caused issues during runtime, as `base` was not initialized within the class or passed to the method. 
- Additionally, including a reference to a Tkinter object within the Tree class would prevent it from being deep-copied due to the limitations of deep copying Tkinter objects.

## Solution:
- The Tree class no longer attempts to use an undefined `base` variable. Instead, the `base` object is passed as an argument to the popup method. 
- This allows the popup method to create and manage the Tkinter Toplevel window without embedding Tkinter objects within the Tree class.

## Changes:
- Modified the popup method to accept `base` as an argument.
- Now, every time `tree.popup` is called, it receives the argument `self.base` ensuring that the Tkinter base object is correctly provided when needed.

## Summary
- This refactor ensures that the Tree class can be deep-copied without issues while maintaining the required GUI functionality and fixing the undefined variable error.
