### PR TITLE
Bump pre-release version to 0.0.1a3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ariadne-roots"
-version = "0.0.1a2"
+version = "0.0.1a3"
 authors = [
   { name="Matthieu Platre", email="mattplatre@gmail.com" },
   { name="Kian Faizi", email="kian@caltech.edu" },


### PR DESCRIPTION
- PyPI version is now 0.0.1a3 for pre-release.