### PR TITLE
Bump version to v0.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ariadne-roots"
-version = "0.0.1a3"
+version = "0.0.1"
 authors = [
   { name="Matthieu Platre", email="mattplatre@gmail.com" },
   { name="Kian Faizi", email="kian@caltech.edu" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
-    "Development Status :: 3 - Alpha"
+    "Development Status :: 4 - Beta"
 ]
 dependencies = [
     "pillow",


### PR DESCRIPTION
- @mplatre has tested the pip package manually and it is working.
- `ariadne-roots` version is 0.0.1 and classifier for Development Status has been bumped from alpha to beta.